### PR TITLE
Shorten swsets

### DIFF
--- a/config/swsets.yaml
+++ b/config/swsets.yaml
@@ -1,111 +1,83 @@
-# Toolchains in core:
-# ictce-5.3.0
-# goolf-1.4.10
-# ictce-7.3.5
+toolchains:
+  - ictce/5.3.0
+  - goolf/1.4.10
+  - ictce/7.3.5
 
 core:
   - ABINIT-7.2.1-x86_64_linux_gnu4.5.eb
-  - ABySS-1.3.4-ictce-5.3.0-Python-2.7.3.eb # easyconfig fix: libreadline-6.2-goolf-1.4.10 fix: preconfigopts = " LDFLAGS='-ltinfo' "
-  - ABySS-1.3.4-goolf-1.4.10-Python-2.7.3.eb # easyconfig fix: libreadline-6.2-goolf-1.4.10 fix: preconfigopts = " LDFLAGS='-ltinfo' "
-  - ABySS-1.5.2-goolf-1.4.10.eb
-  # Not on Debian (Python 2.7.5 problem) - ABySS-1.3.6-goolf-1.4.10-Python-2.7.5.eb
-  - ASE-3.6.0.2515-ictce-5.3.0-Python-2.7.3.eb
-  - ASE-3.6.0.2515-goolf-1.4.10-Python-2.7.3.eb
-  - ASE-3.9.0.4465-ictce-7.3.5-Python-2.7.10.eb
-  - Autoconf-2.69-goolf-1.4.10.eb
-  - Autoconf-2.69-ictce-5.3.0.eb
-  - Automake-1.13.4-goolf-1.4.10.eb
-  - Automake-1.14-ictce-5.3.0.eb
-  - BioPerl-1.6.1-ictce-5.3.0-Perl-5.16.3.eb
-  - BioPerl-1.6.1-goolf-1.4.10-Perl-5.16.3.eb
-  - Boost-1.53.0-ictce-5.3.0-Python-2.7.5.eb
-  - Boost-1.53.0-goolf-1.4.10.eb
-  - Bowtie2-2.2.2-goolf-1.4.10.eb
-  - Bowtie2-2.0.2-ictce-5.3.0.eb
-  - CMake-2.8.12-goolf-1.4.10.eb
-  - CMake-2.8.12-ictce-5.3.0.eb
+  - ABySS/1.3.4-Python-2.7.3 # easyconfig fix: libreadline-6.2-goolf-1.4.10 fix: preconfigopts = " LDFLAGS='-ltinfo' "
+  - ABySS/1.5.2
+  - ASE/3.6.0.2515-Python-2.7.3
+  - ASE/3.6.0.2515-Python-2.7.3
+  - Autoconf/2.69
+  - Automake/1.13.4
+  - Automake/1.14
+  - BioPerl/1.6.1-Perl-5.16.3
+  - BioPerl/1.6.1-Perl-5.16.3
+  - Boost/1.53.0-Python-2.7.5
+  - Bowtie/2-2.2.2
+  - CMake/2.8.12
   - CUDA-5.5.22.eb 
-  # Cufflinks fix: went upstream
-  - Cufflinks-2.0.2-goolf-1.4.10.eb # Sources changed location (project website moved) (In fact, sources from the new site don't work, use old one that are on the server) Fix applied in last EB version: preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
-  - Cufflinks-2.0.2-ictce-5.3.0.eb # Sources changed location (project website moved) (In fact, sources from the new site don't work, use old one that are on the server) Fix applied in last EB version: preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
-  - Cufflinks-2.2.1-goolf-1.4.10.eb
-  - Eigen-3.1.4-goolf-1.4.10.eb
-  - Eigen-3.1.4-ictce-5.3.0.eb
-  - ESPResSo-3.1.1-goolf-1.4.10-parallel.eb
-  - ESPResSo-3.1.1-goolf-1.4.10-serial.eb
-  - ESPResSo-3.1.1-ictce-5.3.0-parallel.eb
-  - ESPResSo-3.1.1-ictce-5.3.0-serial.eb
-  - GDB-7.5.1-goolf-1.4.10.eb
-  - gnuplot-4.6.0-goolf-1.4.10.eb
-  - gnuplot-4.6.0-ictce-5.3.0.eb
-  - GPAW-0.9.0.8965-goolf-1.4.10-Python-2.7.3.eb
-  - GPAW-0.9.0.8965-ictce-5.3.0-Python-2.7.3.eb
-  - GROMACS-4.6.5-goolf-1.4.10-hybrid.eb # regressiontests links broken, these sources have to be downloaded beforehand. # NOT TESTED YET
-  - GROMACS-4.6.5-goolf-1.4.10-mt.eb # regressiontests links broken, these sources have to be downloaded beforehand.
-  - GROMACS-4.6.1-ictce-5.3.0-mt.eb # regressiontests links broken, these sources have to be downloaded beforehand.
-  - GROMACS-4.6.1-ictce-5.3.0-hybrid.eb # regressiontests links broken, these sources have to be downloaded beforehand.
-  - h5utils-1.12.1-goolf-1.4.10.eb # Download sources separately for byacc and ncurses from "invisible-island.net"
-  - h5utils-1.12.1-ictce-5.3.0.eb # Download sources separately for byacc and ncurses from "invisible-island.net"
-  - ictce-7.3.5.eb
+  - Cufflinks/2.0.2 # Sources changed location (project website moved) (In fact, sources from the new site don't work, use old one that are on the server) Fix applied in last EB version: preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
+  - Cufflinks/2.2.1
+  - Eigen/3.1.4
+  - ESPResSo/3.1.1-parallel
+  - ESPResSo/3.1.1-serial
+  - GDB/7.5.1
+  - gnuplot/4.6.0
+  - GPAW/0.9.0.8965-Python-2.7.3
+  - GROMACS/4.6.5-hybrid # regressiontests links broken, these sources have to be downloaded beforehand. # NOT TESTED YET
+  - GROMACS/4.6.5-mt # regressiontests links broken, these sources have to be downloaded beforehand.
+  - h5utils/1.12.1 # Download sources separately for byacc and ncurses from "invisible-island.net"
   - Lmod-5.8-GCC-4.8.2.eb # EasyConfig not in the current repo, add it.
-  - matplotlib-1.3.1-goolf-1.4.10-Python-2.7.6.eb
-  - matplotlib-1.4.3-ictce-7.3.5-Python-2.7.10.eb
-  - Meep-1.2-goolf-1.4.10.eb
-  - Meep-1.2-ictce-5.3.0.eb
-  - mpiBLAST-1.6.0-ictce-7.3.5.eb
-  - netCDF-4.2-goolf-1.4.10.eb
-  - netCDF-4.2-ictce-5.3.0.eb
-  - netCDF-C++-4.2-goolf-1.4.10.eb
-  - netCDF-C++-4.2-ictce-5.3.0.eb # Problem on cluster: MPI linking problem (Problem with gpfs actually, fix: remove -gpfs in the netCDF (4.2.1.1) easyconfig)
-  - netCDF-Fortran-4.2-goolf-1.4.10.eb
-  - netCDF-Fortran-4.2-ictce-5.3.0.eb # Problem on cluster: MPI linking problem (Problem with gpfs actually, fix: remove -gpfs in the netCDF (4.2.1.1) easyconfig)
-  - numpy-1.8.0-ictce-5.3.0-Python-2.7.5.eb
-  - numpy-1.7.1-goolf-1.4.10-Python-2.7.3.eb
-  - OpenFOAM-2.3.0-goolf-1.4.10.eb
-  - OpenFOAM-2.3.0-ictce-5.3.0.eb
+  - matplotlib/1.3.1-Python-2.7.6
+  #ABSENT- matplotlib-1.4.3-ictce-7.3.5-Python-2.7.10.eb
+  - Meep/1.2
+  #ABSENT- mpiBLAST-1.6.0-ictce-7.3.5.eb
+  - netCDF/4.2
+  #ABSENT- netCDF-C++-4.2-goolf-1.4.10.eb
+  #ABSENT- netCDF-C++-4.2-ictce-5.3.0.eb # Problem on cluster: MPI linking problem (Problem with gpfs actually, fix: remove -gpfs in the netCDF (4.2.1.1) easyconfig)
+  #ABSENT- netCDF-Fortran-4.2-goolf-1.4.10.eb
+  #ABSENT- netCDF-Fortran-4.2-ictce-5.3.0.eb # Problem on cluster: MPI linking problem (Problem with gpfs actually, fix: remove -gpfs in the netCDF (4.2.1.1) easyconfig)
+  - numpy/1.8.0-Python-2.7.5
+  - numpy/1.7.1-Python-2.7.3
+  - OpenFOAM/2.3.0
   - OpenMPI-1.8.4-GCC-4.9.2.eb
-  - Perl-5.16.3-goolf-1.4.10.eb # Perl problem comes from the shebang being too long. This problem should disappear at release since the rootinstall will be way closer to the root, we will be well below the 127 characters limit.
-  - Perl-5.16.3-goolf-1.4.10-bare.eb
-  - Perl-5.16.3-ictce-5.3.0.eb # Perl problem comes from the shebang being too long. This problem should disappear at release since the rootinstall will be way closer to the root, we will be well below the 127 characters limit.
-  - Perl-5.16.3-ictce-5.3.0-bare.eb
-  - PyQt-4.11.3-ictce-7.3.5-Python-2.7.10.eb
-  - Python-2.7.6-goolf-1.4.10.eb
-  - Python-2.7.5-ictce-5.3.0.eb
-  - Python-2.7.10-ictce-7.3.5.eb
-  - Python-2.7.10-ictce-7.3.5-bare.eb
-  - Python-3.3.2-goolf-1.4.10.eb # Not available anymore due to extension not available anymore at this version (nose)
-  - Python-3.3.2-ictce-5.3.0.eb # Not available anymore due to extension not available anymore at this version (nose)
-  - Python-3.4.3-ictce-7.3.5.eb
-  - Python-3.4.3-ictce-7.3.5-bare.eb
-  - QuantumESPRESSO-5.0.2-goolf-1.4.10.eb
-  - QuantumESPRESSO-5.0.2-goolf-1.4.10-hybrid.eb
-  - QuantumESPRESSO-5.0.2-ictce-5.3.0.eb
-  - QuantumESPRESSO-5.0.2-ictce-5.3.0-hybrid.eb
-  - QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
-  - R-3.0.2-goolf-1.4.10.eb # Download Java sources separately (normal behavior in EasyBuild) + Easyconfig changes: (Rniftilib: ext_options->rforge_options 0.0-32->0.0-35) (Rsamtools: 1.14.1->1.14.3) (pim: 1.1.5.4->1.1.5.6) + IRanges not downloading correctly
-  - R-3.0.2-ictce-5.3.0.eb # Download Java sources separately (normal behavior in EasyBuild) + IRanges, Biostrings, GenomicRanges, graph, not downloading correctly
-  - R-3.0.2-ictce-5.3.0-bare.eb # Download Java sources separately (normal behavior in EasyBuild)
-  - R-3.2.0-ictce-7.3.5-bare.eb
-  - R-3.2.0-ictce-7.3.5-Rmpi.eb
-  - SAMtools-0.1.19-goolf-1.4.10.eb
-  - SAMtools-0.1.19-ictce-5.3.0.eb
-  - SAMtools-1.2-ictce-5.3.0.eb
-  - SAMtools-1.2-goolf-1.4.10.eb
-  - scipy-0.13.0-goolf-1.4.10-Python-2.7.3.eb 
-  - scipy-0.12.0-ictce-5.3.0-Python-2.7.3.eb # download source manually scipy-0.12.0.tar.gz
-  - Valgrind-3.8.1-goolf-1.4.10.eb # Following fix in easyconfig: preconfigopts = 'export CFLAGS="-I/usr/include/x86_64-linux-gnu $CFLAGS" && '
-  - XCrySDen-1.5.53-goolf-1.4.10.eb # changing dependencies in XCrySDen to libXmu-dev and in Mesa to libX11-dev x11proto-core-dev libXdamage-dev libXext-dev libXfixes-dev + downloading MesaLib sources manually.
-  - XCrySDen-1.5.53-ictce-5.3.0.eb # changing dependencies in XCrySDen to libXmu-dev and in Mesa to libX11-dev x11proto-core-dev libXdamage-dev libXext-dev libXfixes-dev + downloading MesaLib sources manually.
-  - MATLAB-2013a.eb # Sources to get manually + Provide license key in the MATLAB2013a_KEY environment variable
-  - MATLAB-2013b.eb # Sources to get manually + Provide license key in the MATLAB2013b_KEY environment variable
-  - MATLAB-2014a.eb # Sources to get manually + Provide license key in the MATLAB2014a_KEY environment variable
-  - MATLAB-2015a.eb # Sources to get manually + Provide license key in the MATLAB2015a_KEY environment variable
+  - Perl/5.16.3 # Perl problem comes from the shebang being too long. This problem should disappear at release since the rootinstall will be way closer to the root, we will be well below the 127 characters limit.
+  - Perl/5.16.3-bare
+  #ABSENT- PyQt-4.11.3-ictce-7.3.5-Python-2.7.10.eb
+  - Python/2.7.6
+  - Python/2.7.5
+  #ABSENT- Python-2.7.10-ictce-7.3.5.eb
+  #ABSENT- Python-2.7.10-ictce-7.3.5-bare.eb
+  - Python/3.3.2 # Not available anymore due to extension not available anymore at this version (nose)
+  #ABSENT- Python-3.4.3-ictce-7.3.5.eb
+  #ABSENT- Python-3.4.3-ictce-7.3.5-bare.eb
+  - QuantumESPRESSO/5.0.2
+  - QuantumESPRESSO/5.0.2-hybrid
+  - QuantumESPRESSO/5.1.2
+  - R/3.0.2 # Download Java sources separately (normal behavior in EasyBuild) + Easyconfig changes: (Rniftilib: ext_options->rforge_options 0.0-32->0.0-35) (Rsamtools: 1.14.1->1.14.3) (pim: 1.1.5.4->1.1.5.6) + IRanges not downloading correctly
+  - R/3.0.2-bare # Download Java sources separately (normal behavior in EasyBuild)
+  - R/3.2.0-bare
+  #ABSENT- R-3.2.0-ictce-7.3.5-Rmpi.eb
+  - SAMtools/0.1.19
+  #ABSENT- SAMtools-0.1.19-ictce-5.3.0.eb
+  #ABSENT- SAMtools-1.2-ictce-5.3.0.eb
+  - SAMtools/1.2
+  - scipy/0.13.0-Python-2.7.3
+  - scipy/0.12.0-Python-2.7.3 # download source manually scipy-0.12.0.tar.gz
+  - Valgrind/3.8.1 # Following fix in easyconfig: preconfigopts = 'export CFLAGS="-I/usr/include/x86_64-linux-gnu $CFLAGS" && '
+  - XCrySDen/1.5.53 # changing dependencies in XCrySDen to libXmu-dev and in Mesa to libX11-dev x11proto-core-dev libXdamage-dev libXext-dev libXfixes-dev + downloading MesaLib sources manually.
+  #ABSENT- MATLAB-2013a.eb # Sources to get manually + Provide license key in the MATLAB2013a_KEY environment variable
+  #ABSENT- MATLAB-2013b.eb # Sources to get manually + Provide license key in the MATLAB2013b_KEY environment variable
+  #ABSENT- MATLAB-2014a.eb # Sources to get manually + Provide license key in the MATLAB2014a_KEY environment variable
+  #ABSENT- MATLAB-2015a.eb # Sources to get manually + Provide license key in the MATLAB2015a_KEY environment variable
   - TotalView-8.12.0-0-linux-x86-64.eb # sources to get manually
-  - ABAQUS-6.11.1.eb # Sources downloaded manually
-  - ABAQUS-6.14.2.eb # Sources downloaded manually
+  #ABSENT- ABAQUS-6.11.1.eb # Sources downloaded manually
+  #ABSENT- ABAQUS-6.14.2.eb # Sources downloaded manually
   # Not ANYMORE AGAIN. Doesn't make any sense - matplotlib-1.3.0-ictce-5.3.0-Python-2.7.5.eb # Works AGAIN (at least when built at the END of the process. Will try to build it there again and see if the problem occurs one again (A missing module dependency ?))
-  - Perl-5.22.0-ictce-7.3.5-bare.eb
-  - GSL-1.16-ictce-7.3.5.eb
+  #ABSENT- Perl-5.22.0-ictce-7.3.5-bare.eb
+  #ABSENT- GSL-1.16-ictce-7.3.5.eb
 ulhpc:
   - Autoconf-2.69-gcccuda-2.6.10.eb
   - Automake-1.14-gcccuda-2.6.10.eb
@@ -113,32 +85,31 @@ ulhpc:
   - Boost-1.55.0.eb
   - CMake-3.0.0-GCC-4.8.3.eb
   - CUDA-5.5.22-GCC-4.8.2.eb
-  - libxslt-1.1.28-ictce-7.3.5.eb
+  - libxslt/1.1.28
 lcsb:
-  - BEDTools-2.23.0-goolf-1.4.10.eb
-  - BWA-0.7.12-goolf-1.4.10.eb
+  - BEDTools/2.23.0
+  - BWA/0.7.12
   - GATK-3.3-0-Java-1.7.0_21.eb
   - picard-1.130.eb
   - fastqc-0.11.2.eb
-  - TopHat-2.0.14-goolf-1.4.10.eb
-  - TopHat-2.0.14-ictce-5.3.0.eb
-  - EMBOSS-6.6.0-nodep-goolf-1.4.10.eb
-  - Cython-0.22-goolf-1.4.10-Python-2.7.3.eb
-  - Circos-0.64-ictce-5.5.0-Perl-5.18.2.eb
-  - MUSCLE-3.8.31-goolf-1.4.10.eb
-  - bam2fastq-1.1.0-goolf-1.4.10.eb
-  - parallel-20130122-goolf-1.4.10.eb
+  - TopHat/2.0.14
+  - EMBOSS/6.6.0-nodep
+  - Cython/0.22-Python-2.7.3
+  - Circos/0.64-Perl-5.18.2
+  - MUSCLE/3.8.31
+  - bam2fastq/1.1.0
+  - parallel/20130122
   - BLAST-2.2.26-Linux_x86_64.eb
-  - BLAST+-2.2.28-goolf-1.4.10.eb
-  - BLAST+-2.2.28-goolf-1.4.10-Python-2.7.3.eb
-  - pandas-0.16.0-goolf-1.4.10-Python-3.3.2.eb
-  - Trinity-2.0.6-goolf-1.4.10.eb
-  - PLINK-1.07-ictce-7.3.5.eb
+  - BLAST+/2.2.28
+  - BLAST+/2.2.28-Python-2.7.3
+  - pandas/0.16.0-Python-3.3.2
+  - Trinity/2.0.6
+  - PLINK/1.07
   - PLINK-1.90-beta3r-Linux_x86_64.eb
   - SNPTEST-v2.5.1_Linux_x86_64_static.eb
-  - HMMER-3.1b2-ictce-7.3.5.eb
-  - FASTX-Toolkit-0.0.14-goolf-1.4.10.eb
+  - HMMER/3.1b2
+  - FASTX-Toolkit/0.0.14
   - Trimmomatic-0.33-Java-1.7.0_21.eb
-  - Biopython-1.65-ictce-7.3.5-Python-3.4.3
-  - BCFtools-1.2-ictce-7.3.5.eb
+  - Biopython/1.65-Python-3.4.3
+  - BCFtools/1.2
 # To create a "all" software set, use this command: "find -name "*.eb" -exec basename {} \; | sed "s/^/  - /g" > swsets.yaml"


### PR DESCRIPTION
Shorten the software set by using the <software>/<version>-<versionsuffix> syntax and removing software not present in the default ULHPC github easyconfig repository (https://github.com/ULHPC/easybuild-easyconfigs).